### PR TITLE
Support `JuMP.value` for Logical Variables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,10 +8,10 @@ JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
+Aqua = "0.8"
 JuMP = "1.16"
 Reexport = "1"
 julia = "1.6"
-Aqua = "0.8"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -267,6 +267,16 @@ function binary_variable(vref::LogicalVariableRef)
 end
 
 """
+    JuMP.value(vref::LogicalVariableRef)::Number
+
+Returns the optimized value of `vref`. This simply dispatches on the 
+underlying [`binary_variable`](@ref).
+"""
+function JuMP.value(vref::LogicalVariableRef)
+    return JuMP.value(binary_variable(vref))
+end
+
+"""
     JuMP.delete(model::JuMP.AbstractModel, vref::LogicalVariableRef)::Nothing
 
 Delete the logical variable associated with `vref` from the `GDP model`.

--- a/test/solve.jl
+++ b/test/solve.jl
@@ -13,25 +13,23 @@ function test_linear_gdp_example(m)
     @disjunction(m, inner, [W[1], W[2]], Disjunct(Y[1]))
     @disjunction(m, outer, [Y[1], Y[2]])
 
-    optimize!(m, gdp_method = BigM())
+    @test optimize!(m, gdp_method = BigM()) isa Nothing
     @test termination_status(m) == MOI.OPTIMAL
     @test objective_value(m) ≈ 11
     @test value.(x) ≈ [9,2]
-    bins = gdp_data(m).indicator_to_binary
-    @test value(bins[Y[1]]) ≈ 0
-    @test value(bins[Y[2]]) ≈ 1
-    @test value(bins[W[1]]) ≈ 0
-    @test value(bins[W[2]]) ≈ 0
+    @test value(Y[1]) ≈ 0
+    @test value(Y[2]) ≈ 1
+    @test value(W[1]) ≈ 0
+    @test value(W[2]) ≈ 0
 
-    optimize!(m, gdp_method = Hull())
+    @test optimize!(m, gdp_method = Hull()) isa Nothing
     @test termination_status(m) == MOI.OPTIMAL
     @test objective_value(m) ≈ 11
     @test value.(x) ≈ [9,2]
-    bins = gdp_data(m).indicator_to_binary
-    @test value(bins[Y[1]]) ≈ 0
-    @test value(bins[Y[2]]) ≈ 1
-    @test value(bins[W[1]]) ≈ 0
-    @test value(bins[W[2]]) ≈ 0
+    @test value(Y[1]) ≈ 0
+    @test value(Y[2]) ≈ 1
+    @test value(W[1]) ≈ 0
+    @test value(W[2]) ≈ 0
     @test value(variable_by_name(m, "x[1]_Y[1]")) ≈ 0
     @test value(variable_by_name(m, "x[1]_Y[2]")) ≈ 9
     @test value(variable_by_name(m, "x[1]_W[1]")) ≈ 0
@@ -55,8 +53,8 @@ function test_generic_model(m)
     @disjunction(m, inner, [W[1], W[2]], Disjunct(Y[1]))
     @disjunction(m, outer, [Y[1], Y[2]])
 
-    optimize!(m, gdp_method = BigM())
-    optimize!(m, gdp_method = Hull())
+    @test optimize!(m, gdp_method = BigM()) isa Nothing
+    @test optimize!(m, gdp_method = Hull()) isa Nothing
 
     # TODO add meaningful tests to check the constraints/variables
 end


### PR DESCRIPTION
Closes #94. It also alphabetizes the Project file to fix an Aqua test failure.