### PR TITLE
Update to use `JuMP.SkipModelConvertScalarSetWrapper`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 Aqua = "0.8"
-JuMP = "1.16"
+JuMP = "1.17"
 Reexport = "1"
 julia = "1.6"
 

--- a/src/DisjunctiveProgramming.jl
+++ b/src/DisjunctiveProgramming.jl
@@ -8,8 +8,8 @@ Reexport.@reexport using JuMP
 using Base.Meta
 
 # Create aliases
-const _MOI = JuMP.MOI
-const _MOIUC = JuMP.MOIU.CleverDicts
+import JuMP.MOI as _MOI
+import JuMP.MOIU.CleverDicts as _MOIUC
 
 # Load in the source files
 include("datatypes.jl")

--- a/test/constraints/proposition.jl
+++ b/test/constraints/proposition.jl
@@ -21,7 +21,7 @@ function test_proposition_add_fail()
     @test_throws ErrorException @constraint(m, sin(y[1]) := true)
     @test_throws ErrorException @constraint(m, logical_or(y...) == true)
     @test_throws VariableNotOwned @constraint(GDPModel(), logical_or(y...) := true)
-    @test_throws AssertionError add_constraint(m, ScalarConstraint(logical_or(y...), MOI.LessThan(42)))
+    @test_throws ErrorException add_constraint(m, ScalarConstraint(logical_or(y...), MOI.LessThan(42)))
 end
 
 function test_implication_add_success()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
+import DisjunctiveProgramming as DP
 using DisjunctiveProgramming
 using Test
-
-const DP = DisjunctiveProgramming
 
 include("utilities.jl")
 


### PR DESCRIPTION
This updates to JuMP `v1.17` to take advantage of the new `JuMP.SkipModelConvertScalarSetWrapper` set to throw better error messages. I also cleaned up the package aliases.