### PR TITLE
Support Logical Complements

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ Logical variables are JuMP `AbstractVariable`s with two fields: `fix_value` and 
 @variable(model, Y[1:3], Logical)
 ```
 
+When making logical variables for disjunctions with only two disjuncts, we can use the `logical_compliment` argument to prevent creating uncessary binary variables when reformulating:
+
+```julia
+
+@variable(model, Y1, Logical)
+@variable(model, Y2, Logical, logical_compliment = Y1) # Y2 ⇔ ¬Y1
+```
+
 ## Logical Constraints
 
 Two types of logical constraints are supported:

--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ Logical variables are JuMP `AbstractVariable`s with two fields: `fix_value` and 
 @variable(model, Y[1:3], Logical)
 ```
 
-When making logical variables for disjunctions with only two disjuncts, we can use the `logical_compliment` argument to prevent creating uncessary binary variables when reformulating:
+When making logical variables for disjunctions with only two disjuncts, we can use the `logical_complement` argument to prevent creating uncessary binary variables when reformulating:
 
 ```julia
 
 @variable(model, Y1, Logical)
-@variable(model, Y2, Logical, logical_compliment = Y1) # Y2 ⇔ ¬Y1
+@variable(model, Y2, Logical, logical_complement = Y1) # Y2 ⇔ ¬Y1
 ```
 
 ## Logical Constraints

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -85,6 +85,14 @@ Logical variables are JuMP `AbstractVariable`s with two fields: `fix_value` and 
 @variable(model, Y[1:3], Logical)
 ```
 
+When making logical variables for disjunctions with only two disjuncts, we can use the `logical_compliment` argument to prevent creating uncessary binary variables when reformulating:
+
+```julia
+
+@variable(model, Y1, Logical)
+@variable(model, Y2, Logical, logical_compliment = Y1) # Y2 ⇔ ¬Y1
+```
+
 ## Logical Constraints
 
 Two types of logical constraints are supported:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -85,12 +85,12 @@ Logical variables are JuMP `AbstractVariable`s with two fields: `fix_value` and 
 @variable(model, Y[1:3], Logical)
 ```
 
-When making logical variables for disjunctions with only two disjuncts, we can use the `logical_compliment` argument to prevent creating uncessary binary variables when reformulating:
+When making logical variables for disjunctions with only two disjuncts, we can use the `logical_complement` argument to prevent creating uncessary binary variables when reformulating:
 
 ```julia
 
 @variable(model, Y1, Logical)
-@variable(model, Y2, Logical, logical_compliment = Y1) # Y2 ⇔ ¬Y1
+@variable(model, Y2, Logical, logical_complement = Y1) # Y2 ⇔ ¬Y1
 ```
 
 ## Logical Constraints

--- a/src/bigm.jl
+++ b/src/bigm.jl
@@ -171,26 +171,27 @@ function set_variable_bound_info(vref::JuMP.AbstractVariableRef, ::BigM)
     return lb, ub
 end
 
+# Extend reformulate_disjunct_constraint
 function reformulate_disjunct_constraint(
     model::JuMP.AbstractModel,
     con::JuMP.ScalarConstraint{T, S},
-    bvref::JuMP.AbstractVariableRef,
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
     method::BigM
 ) where {T, S <: _MOI.LessThan}
     M = _get_M_value(con.func, con.set, method)
-    new_func = JuMP.@expression(model, con.func - M*(1-bvref))
+    new_func = JuMP.@expression(model, con.func - M*(1 - bvref))
     reform_con = JuMP.build_constraint(error, new_func, con.set)
     return [reform_con]
 end
 function reformulate_disjunct_constraint(
     model::JuMP.AbstractModel,
     con::JuMP.VectorConstraint{T, S, R},
-    bvref::JuMP.AbstractVariableRef,
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
     method::BigM
 ) where {T, S <: _MOI.Nonpositives, R}
     M = [_get_M_value(func, con.set, method) for func in con.func]
     new_func = JuMP.@expression(model, [i=1:con.set.dimension],
-        con.func[i] - M[i]*(1-bvref)
+        con.func[i] - M[i]*(1 - bvref)
     )
     reform_con = JuMP.build_constraint(error, new_func, con.set)
     return [reform_con]
@@ -198,23 +199,23 @@ end
 function reformulate_disjunct_constraint(
     model::JuMP.AbstractModel,
     con::JuMP.ScalarConstraint{T, S},
-    bvref::JuMP.AbstractVariableRef,
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
     method::BigM
 ) where {T, S <: _MOI.GreaterThan}
     M = _get_M_value(con.func, con.set, method)
-    new_func = JuMP.@expression(model, con.func + M*(1-bvref))
+    new_func = JuMP.@expression(model, con.func + M*(1 - bvref))
     reform_con = JuMP.build_constraint(error, new_func, con.set)
     return [reform_con]
 end
 function reformulate_disjunct_constraint(
     model::JuMP.AbstractModel,
     con::JuMP.VectorConstraint{T, S, R},
-    bvref::JuMP.AbstractVariableRef,
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
     method::BigM
 ) where {T, S <: _MOI.Nonnegatives, R}
     M = [_get_M_value(func, con.set, method) for func in con.func]
     new_func = JuMP.@expression(model, [i=1:con.set.dimension],
-        con.func[i] + M[i]*(1-bvref)
+        con.func[i] + M[i]*(1 - bvref)
     )
     reform_con = build_constraint(error, new_func, con.set)
     return [reform_con]
@@ -222,12 +223,12 @@ end
 function reformulate_disjunct_constraint(
     model::JuMP.AbstractModel,
     con::JuMP.ScalarConstraint{T, S},
-    bvref::JuMP.AbstractVariableRef,
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
     method::BigM
 ) where {T, S <: Union{_MOI.Interval, _MOI.EqualTo}}
     M = _get_M_value(con.func, con.set, method)
-    new_func_gt = JuMP.@expression(model, con.func + M[1]*(1-bvref))
-    new_func_lt = JuMP.@expression(model, con.func - M[2]*(1-bvref))
+    new_func_gt = JuMP.@expression(model, con.func + M[1]*(1 - bvref))
+    new_func_lt = JuMP.@expression(model, con.func - M[2]*(1 - bvref))
     set_values = _set_values(con.set)
     reform_con_gt = build_constraint(error, new_func_gt, _MOI.GreaterThan(set_values[1]))
     reform_con_lt = build_constraint(error, new_func_lt, _MOI.LessThan(set_values[2]))
@@ -236,15 +237,15 @@ end
 function reformulate_disjunct_constraint(
     model::JuMP.AbstractModel,
     con::JuMP.VectorConstraint{T, S, R},
-    bvref::JuMP.AbstractVariableRef,
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
     method::BigM
 ) where {T, S <: _MOI.Zeros, R}
     M = [_get_M_value(func, con.set, method) for func in con.func]
     new_func_nn = JuMP.@expression(model, [i=1:con.set.dimension],
-        con.func[i] + M[i][1]*(1-bvref)
+        con.func[i] + M[i][1]*(1 - bvref)
     )
     new_func_np = JuMP.@expression(model, [i=1:con.set.dimension],
-        con.func[i] - M[i][2]*(1-bvref)
+        con.func[i] - M[i][2]*(1 - bvref)
     )
     reform_con_nn = JuMP.build_constraint(error, new_func_nn, _MOI.Nonnegatives(con.set.dimension))
     reform_con_np = JuMP.build_constraint(error, new_func_np, _MOI.Nonpositives(con.set.dimension))

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -302,17 +302,17 @@ function _check_disjunction(
             _error("`$lvref` is not a valid logical variable reference.")
         end
     end
-    if length(lvrefs) != 2 && any(has_logical_compliment.(lvrefs))
-        _error("Can only use logical compliment variables in Disjunctions " *
+    if length(lvrefs) != 2 && any(has_logical_complement.(lvrefs))
+        _error("Can only use logical complement variables in Disjunctions " *
                "with two disjuncts.")
-    elseif length(lvrefs) == 2 && any(has_logical_compliment.(lvrefs))
+    elseif length(lvrefs) == 2 && any(has_logical_complement.(lvrefs))
         T = JuMP.value_type(M)
         V = JuMP.variable_ref_type(M)
         expr1 = convert(JuMP.GenericAffExpr{T, V}, binary_variable(first(lvrefs)))
         expr2 = 1 - binary_variable(last(lvrefs))
         if !JuMP.isequal_canonical(expr1, expr2)
-            _error("When using logical compliment variables in a disjunction, " *
-                   "both logical variables must be the compliment of one another.")
+            _error("When using logical complement variables in a disjunction, " *
+                   "both logical variables must be the complement of one another.")
         end
     end
     return lvrefs
@@ -366,7 +366,7 @@ function _disjunction(
     # create the disjunction
     dref = _create_disjunction(_error, model, structure, name, false)
     # add the exactly one constraint if desired
-    if exactly1 && !any(has_logical_compliment.(structure))
+    if exactly1 && !any(has_logical_complement.(structure))
         lvars = JuMP.constraint_object(dref).indicators
         func = JuMP.model_convert.(model, Any[1, lvars...])
         set = _MOIExactly(length(lvars) + 1)
@@ -402,9 +402,9 @@ function _disjunction(
     for (kwarg, _) in extra_kwargs
         _error("Unrecognized keyword argument $kwarg.")
     end
-    # check that no logical compliment is used
-    if any(has_logical_compliment.(structure))
-        _error("Logical compliment variables are not supported for " *
+    # check that no logical complement is used
+    if any(has_logical_complement.(structure))
+        _error("Logical complement variables are not supported for " *
                "use in nested disjunctions.")
     end
     # create the disjunction
@@ -412,7 +412,7 @@ function _disjunction(
     obj = constraint_object(dref)
     _add_indicator_var(_DisjunctConstraint(obj, tag.indicator), dref, model)
     # add the exactly one constraint if desired
-    if exactly1 && !any(has_logical_compliment.(structure))
+    if exactly1 && !any(has_logical_complement.(structure))
         lvars = JuMP.constraint_object(dref).indicators
         func = LogicalVariableRef{M}[tag.indicator, lvars...]
         set = _MOIExactly(length(lvars) + 1)

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -291,11 +291,28 @@ function _add_indicator_var(
     return
 end
 # check disjunction
-function _check_disjunction(_error, lvrefs::AbstractVector{<:LogicalVariableRef}, model::JuMP.AbstractModel)
+function _check_disjunction(
+    _error,
+    lvrefs::AbstractVector{<:LogicalVariableRef},
+    model::M
+    ) where {M <: JuMP.AbstractModel}
     isequal(unique(lvrefs), lvrefs) || _error("Not all the logical indicator variables are unique.")
     for lvref in lvrefs
         if !JuMP.is_valid(model, lvref)
             _error("`$lvref` is not a valid logical variable reference.")
+        end
+    end
+    if length(lvrefs) != 2 && any(has_logical_compliment.(lvrefs))
+        _error("Can only use logical compliment variables in Disjunctions " *
+               "with two disjuncts.")
+    elseif length(lvrefs) == 2 && any(has_logical_compliment.(lvrefs))
+        T = JuMP.value_type(M)
+        V = JuMP.variable_ref_type(M)
+        expr1 = convert(JuMP.GenericAffExpr{T, V}, binary_variable(first(lvrefs)))
+        expr2 = 1 - binary_variable(last(lvrefs))
+        if !JuMP.isequal_canonical(expr1, expr2)
+            _error("When using logical compliment variables in a disjunction, " *
+                   "both logical variables must be the compliment of one another.")
         end
     end
     return lvrefs
@@ -349,7 +366,7 @@ function _disjunction(
     # create the disjunction
     dref = _create_disjunction(_error, model, structure, name, false)
     # add the exactly one constraint if desired
-    if exactly1
+    if exactly1 && !any(has_logical_compliment.(structure))
         lvars = JuMP.constraint_object(dref).indicators
         func = JuMP.model_convert.(model, Any[1, lvars...])
         set = _MOIExactly(length(lvars) + 1)
@@ -385,12 +402,17 @@ function _disjunction(
     for (kwarg, _) in extra_kwargs
         _error("Unrecognized keyword argument $kwarg.")
     end
+    # check that no logical compliment is used
+    if any(has_logical_compliment.(structure))
+        _error("Logical compliment variables are not supported for " *
+               "use in nested disjunctions.")
+    end
     # create the disjunction
     dref = _create_disjunction(_error, model, structure, name, true)
     obj = constraint_object(dref)
     _add_indicator_var(_DisjunctConstraint(obj, tag.indicator), dref, model)
     # add the exactly one constraint if desired
-    if exactly1
+    if exactly1 && !any(has_logical_compliment.(structure))
         lvars = JuMP.constraint_object(dref).indicators
         func = LogicalVariableRef{M}[tag.indicator, lvars...]
         set = _MOIExactly(length(lvars) + 1)

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -31,13 +31,13 @@ A variable type the logical variables associated with disjuncts in a [`Disjuncti
 **Fields**
 - `fix_value::Union{Nothing, Bool}`: A fixed boolean value if there is one.
 - `start_value::Union{Nothing, Bool}`: An initial guess if there is one.
-- `logical_compliment::Union{Nothing, LogicalVariableRef}`: The logical compliment of
+- `logical_complement::Union{Nothing, LogicalVariableRef}`: The logical complement of
    this variable if there is one.
 """
 struct LogicalVariable <: JuMP.AbstractVariable 
     fix_value::Union{Nothing, Bool}
     start_value::Union{Nothing, Bool}
-    logical_compliment::Union{Nothing, LogicalVariableRef}
+    logical_complement::Union{Nothing, LogicalVariableRef}
 end
 
 # Wrapper variable type for including arbitrary tags that will be used for 

--- a/src/hull.jl
+++ b/src/hull.jl
@@ -104,7 +104,7 @@ end
 function _disaggregate_expression(
     model::JuMP.AbstractModel, 
     vref::JuMP.AbstractVariableRef, 
-    bvref::JuMP.AbstractVariableRef, 
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr}, 
     method::_Hull
     )
     if JuMP.is_binary(vref) || !haskey(method.disjunct_variables, (vref, bvref)) #keep any binary variables or nested disaggregated variables unchanged 
@@ -117,7 +117,7 @@ end
 function _disaggregate_expression(
     model::JuMP.AbstractModel, 
     aff::JuMP.GenericAffExpr, 
-    bvref::JuMP.AbstractVariableRef, 
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr}, 
     method::_Hull
     )
     new_expr = @expression(model, aff.constant*bvref) #multiply constant by binary indicator variable
@@ -137,7 +137,7 @@ end
 function _disaggregate_expression(
     model::JuMP.AbstractModel, 
     quad::JuMP.GenericQuadExpr, 
-    bvref::JuMP.AbstractVariableRef, 
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr}, 
     method::_Hull
     )
     #get affine part
@@ -155,7 +155,7 @@ end
 function _disaggregate_nl_expression(
     ::JuMP.AbstractModel, 
     c::Number, 
-    ::JuMP.AbstractVariableRef, 
+    ::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr}, 
     ::_Hull
     )
     return c
@@ -164,7 +164,7 @@ end
 function _disaggregate_nl_expression(
     ::JuMP.AbstractModel, 
     vref::JuMP.AbstractVariableRef, 
-    bvref::JuMP.AbstractVariableRef, 
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr}, 
     method::_Hull
     )
     ϵ = method.value
@@ -179,7 +179,7 @@ end
 function _disaggregate_nl_expression(
     ::JuMP.AbstractModel, 
     aff::JuMP.GenericAffExpr, 
-    bvref::JuMP.AbstractVariableRef, 
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr}, 
     method::_Hull
     )
     new_expr = aff.constant
@@ -200,7 +200,7 @@ end
 function _disaggregate_nl_expression(
     model::JuMP.AbstractModel, 
     quad::JuMP.GenericQuadExpr, 
-    bvref::JuMP.AbstractVariableRef, 
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr}, 
     method::_Hull)
     #get affine part
     new_expr = _disaggregate_nl_expression(model, quad.aff, bvref, method)
@@ -217,7 +217,7 @@ end
 function _disaggregate_nl_expression(
     model::JuMP.AbstractModel, 
     nlp::NLP, 
-    bvref::JuMP.AbstractVariableRef, 
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr}, 
     method::_Hull
     ) where {NLP <: JuMP.GenericNonlinearExpr}
     new_args = Vector{Any}(undef, length(nlp.args))
@@ -265,7 +265,7 @@ end
 function reformulate_disjunct_constraint(
     model::JuMP.AbstractModel, 
     con::JuMP.ScalarConstraint{T, S}, 
-    bvref::JuMP.AbstractVariableRef, 
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr}, 
     method::_Hull
 ) where {T <: JuMP.AbstractJuMPScalar, S <: Union{_MOI.LessThan, _MOI.GreaterThan, _MOI.EqualTo}}
     new_func = _disaggregate_expression(model, con.func, bvref, method)
@@ -277,7 +277,7 @@ end
 function reformulate_disjunct_constraint(
     model::JuMP.AbstractModel, 
     con::JuMP.VectorConstraint{T, S, R}, 
-    bvref::JuMP.AbstractVariableRef, 
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr}, 
     method::_Hull
 ) where {T <: JuMP.AbstractJuMPScalar, S <: Union{_MOI.Nonpositives, _MOI.Nonnegatives, _MOI.Zeros}, R}
     new_func = JuMP.@expression(model, [i=1:con.set.dimension],
@@ -289,7 +289,7 @@ end
 function reformulate_disjunct_constraint(
     model::JuMP.AbstractModel, 
     con::JuMP.ScalarConstraint{T, S}, 
-    bvref::JuMP.AbstractVariableRef,
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
     method::_Hull
 ) where {T <: JuMP.GenericNonlinearExpr, S <: Union{_MOI.LessThan, _MOI.GreaterThan, _MOI.EqualTo}}
     con_func = _disaggregate_nl_expression(model, con.func, bvref, method)
@@ -306,7 +306,7 @@ end
 function reformulate_disjunct_constraint(
     model::JuMP.AbstractModel, 
     con::JuMP.VectorConstraint{T, S, R}, 
-    bvref::JuMP.AbstractVariableRef,
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
     method::_Hull
 ) where {T <: JuMP.GenericNonlinearExpr, S <: Union{_MOI.Nonpositives, _MOI.Nonnegatives, _MOI.Zeros}, R}
     con_func = JuMP.@expression(model, [i=1:con.set.dimension],
@@ -326,7 +326,7 @@ end
 function reformulate_disjunct_constraint(
     model::JuMP.AbstractModel, 
     con::JuMP.ScalarConstraint{T, S}, 
-    bvref::JuMP.AbstractVariableRef,
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
     method::_Hull
 ) where {T <: JuMP.AbstractJuMPScalar, S <: _MOI.Interval}
     new_func = _disaggregate_expression(model, con.func, bvref, method)
@@ -339,7 +339,7 @@ end
 function reformulate_disjunct_constraint(
     model::JuMP.AbstractModel, 
     con::JuMP.ScalarConstraint{T, S}, 
-    bvref::JuMP.AbstractVariableRef,
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
     method::_Hull
 ) where {T <: JuMP.GenericNonlinearExpr, S <: _MOI.Interval}
     con_func = _disaggregate_nl_expression(model, con.func, bvref, method)

--- a/src/indicator.jl
+++ b/src/indicator.jl
@@ -11,6 +11,15 @@ function reformulate_disjunct_constraint(
     reform_con = JuMP.build_constraint(error, [1*bvref, con.func], _MOI.Indicator{_MOI.ACTIVATE_ON_ONE}(con.set))
     return [reform_con]
 end
+function reformulate_disjunct_constraint(
+    ::JuMP.AbstractModel,
+    con::JuMP.ScalarConstraint{T, S},
+    bvref::JuMP.GenericAffExpr,
+    ::Indicator
+) where {T, S}
+    reform_con = JuMP.build_constraint(error, [1 - bvref, con.func], _MOI.Indicator{_MOI.ACTIVATE_ON_ZERO}(con.set))
+    return [reform_con]
+end
 #vectorized disjunct constraint
 function reformulate_disjunct_constraint(
     ::JuMP.AbstractModel,
@@ -21,6 +30,18 @@ function reformulate_disjunct_constraint(
     set = _vec_to_scalar_set(con.set)
     return [
         JuMP.build_constraint(error, [1*bvref, f], _MOI.Indicator{_MOI.ACTIVATE_ON_ONE}(set)) 
+        for f in con.func
+    ]
+end
+function reformulate_disjunct_constraint(
+    ::JuMP.AbstractModel,
+    con::JuMP.VectorConstraint{T, S},
+    bvref::JuMP.GenericAffExpr,
+    ::Indicator
+) where {T, S}
+    set = _vec_to_scalar_set(con.set)
+    return [
+        JuMP.build_constraint(error, [1 - bvref, f], _MOI.Indicator{_MOI.ACTIVATE_ON_ZERO}(set)) 
         for f in con.func
     ]
 end

--- a/src/logic.jl
+++ b/src/logic.jl
@@ -219,24 +219,26 @@ end
 ################################################################################
 # cardinality constraint reformulation
 function _reformulate_selector(
-    model::JuMP.AbstractModel, 
+    model::M, 
     func::Vector{JuMP.AbstractJuMPScalar}, 
     set::AbstractCardinalitySet
-    )
+    ) where {M <: JuMP.AbstractModel}
     bvrefs = [binary_variable(lvref) for lvref in func[2:end]]
     c = JuMP.constant(func[1])
     new_set = _vec_to_scalar_set(set)(c)
-    cref = JuMP.@constraint(model, sum(bvrefs) in new_set)
+    init = zero(JuMP.value_type(M))
+    cref = JuMP.@constraint(model, sum(bvrefs, init = init) in new_set)
     push!(_reformulation_constraints(model), cref)
 end
 function _reformulate_selector(
-    model::JuMP.AbstractModel, 
+    model::M, 
     func::Vector{<:LogicalVariableRef}, 
     set::AbstractCardinalitySet
-    )
+    ) where {M <: JuMP.AbstractModel}
     bvref, bvrefs... = [binary_variable(lvref) for lvref in func]
     new_set = _vec_to_scalar_set(set)(0)
-    cref = JuMP.@constraint(model, sum(bvrefs) - bvref in new_set)
+    init = zero(JuMP.value_type(M))
+    cref = JuMP.@constraint(model, sum(bvrefs, init = init) - bvref in new_set)
     push!(_reformulation_constraints(model), cref)
 end
 

--- a/src/reformulate.jl
+++ b/src/reformulate.jl
@@ -78,8 +78,9 @@ function _reformulate_disjunctions(model::JuMP.AbstractModel, method::AbstractRe
         dref = DisjunctionRef(model, idx)
         if requires_exactly1(method) && !haskey(gdp_data(model).exactly1_constraints, dref) &&
             !any(has_logical_compliment.(disj.constraint.indicators))
-            error("Reformulation method `$method` requires disjunctions where only 1 disjunct is selected, " *
-                  "but `exactly1 = false` for disjunction `$dref`.")
+            error("Reformulation method `$method` requires disjunctions where only 1 disjunct is selected, ",
+                  "but `exactly1 = false` or none of the logical variables are logical compliments ",
+                  "for disjunction `$dref`.")
         end
         if requires_variable_bound_info(method)
             for vref in _get_disjunction_variables(model, disj.constraint)

--- a/src/reformulate.jl
+++ b/src/reformulate.jl
@@ -76,7 +76,8 @@ function _reformulate_disjunctions(model::JuMP.AbstractModel, method::AbstractRe
     for (idx, disj) in _disjunctions(model)
         disj.constraint.nested && continue #only reformulate top level disjunctions
         dref = DisjunctionRef(model, idx)
-        if requires_exactly1(method) && !haskey(gdp_data(model).exactly1_constraints, dref)
+        if requires_exactly1(method) && !haskey(gdp_data(model).exactly1_constraints, dref) &&
+            !any(has_logical_compliment.(disj.constraint.indicators))
             error("Reformulation method `$method` requires disjunctions where only 1 disjunct is selected, " *
                   "but `exactly1 = false` for disjunction `$dref`.")
         end
@@ -94,7 +95,7 @@ function _reformulate_disjunctions(model::JuMP.AbstractModel, method::AbstractRe
     end
 end
 
-# disjuncts
+# individual disjunctions
 """
     reformulate_disjunction(
         model::JuMP.AbstractModel, 
@@ -137,7 +138,7 @@ end
     reformulate_disjunct_constraint(
         model::JuMP.AbstractModel,  
         con::JuMP.AbstractConstraint, 
-        bvref::JuMP.AbstractVariableRef,
+        bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
         method::AbstractReformulationMethod
     )
 
@@ -148,7 +149,7 @@ constraint. If `method` needs to specify how to reformulate the entire disjuncti
 function reformulate_disjunct_constraint(
     model::JuMP.AbstractModel,  
     con::Disjunction, 
-    bvref::JuMP.AbstractVariableRef,
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
     method::AbstractReformulationMethod
 )
     ref_cons = reformulate_disjunction(model, con, method)
@@ -163,7 +164,7 @@ end
 function reformulate_disjunct_constraint(
     model::JuMP.AbstractModel,  
     con::JuMP.AbstractConstraint, 
-    bvref::JuMP.AbstractVariableRef,
+    bvref::Union{JuMP.AbstractVariableRef, JuMP.GenericAffExpr},
     method::AbstractReformulationMethod
 )
     error("$(typeof(method)) reformulation for constraint $con is not supported yet.")

--- a/src/reformulate.jl
+++ b/src/reformulate.jl
@@ -77,9 +77,9 @@ function _reformulate_disjunctions(model::JuMP.AbstractModel, method::AbstractRe
         disj.constraint.nested && continue #only reformulate top level disjunctions
         dref = DisjunctionRef(model, idx)
         if requires_exactly1(method) && !haskey(gdp_data(model).exactly1_constraints, dref) &&
-            !any(has_logical_compliment.(disj.constraint.indicators))
+            !any(has_logical_complement.(disj.constraint.indicators))
             error("Reformulation method `$method` requires disjunctions where only 1 disjunct is selected, ",
-                  "but `exactly1 = false` or none of the logical variables are logical compliments ",
+                  "but `exactly1 = false` or none of the logical variables are logical complements ",
                   "for disjunction `$dref`.")
         end
         if requires_variable_bound_info(method)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -35,11 +35,14 @@ function JuMP.build_variable(
     elseif info.has_start && !isone(info.start) && !iszero(info.start)
         _error("Invalid start value, must be false or true.")
     elseif (info.has_start || info.has_fix) && !isnothing(logical_compliment)
-        _error("Cannot fix or provide a start value for logical variable " *
-               "that has a logical compliment variable.")
+        _error("Cannot fix or provide a start value for a logical variable " *
+               "that is a logical compliment variable. Try adding these " *
+               "properties to the variable it is the compliment of.")
     elseif !isnothing(logical_compliment) && has_logical_compliment(logical_compliment)
         _error("Cannot specify a logical compliment that itself is a " *
-               "logical compliment.")
+               "logical compliment. For two logical variables that " *
+               "are the compliment of one another, only use the " * 
+               "`logical_compliment` argument on one of them.")
     end
 
     # create the variable
@@ -227,7 +230,8 @@ function JuMP.set_start_value(
     value::Union{Nothing, Bool}
     )
     if has_logical_compliment(vref)
-        error("Cannot set the start value of a variable with a logical compliment.")
+        error("Cannot set the start value of a logical compliment variable. ",
+              "Try setting the start value of its logical compliment instead.")
     end
     new_var = LogicalVariable(JuMP.fix_value(vref), value, nothing)
     _set_variable_object(vref, new_var)
@@ -263,7 +267,8 @@ new one.
 """
 function JuMP.fix(vref::LogicalVariableRef, value::Bool)
     if has_logical_compliment(vref)
-        error("Cannot fix value of a variable with a logical compliment.")
+        error("Cannot fix value of a logical variable compliment. ",
+             "Try fixing its logical compliment instead.")
     end
     new_var = LogicalVariable(value, JuMP.start_value(vref), nothing)
     _set_variable_object(vref, new_var)

--- a/test/constraints/disjunction.jl
+++ b/test/constraints/disjunction.jl
@@ -38,6 +38,11 @@ function test_disjunction_add_fail()
     @variable(model, w[1:3], Logical)
     @constraint(model, [i = 1:2], x == 5, Disjunct(w[i]))
     @test_throws ErrorException disjunction(model, w, Disjunct(w[3]), bad_key = 42)
+
+    @variable(model, yc[i = 1:2], Logical, logical_compliment = y[i])
+    @test_throws ErrorException disjunction(model, [yc[1]])
+    @test_throws ErrorException disjunction(model, [yc[1], y[2]])
+    @test_throws ErrorException disjunction(model, [y[1], yc[1]], Disjunct(y[2]))
 end
 
 function test_disjunction_add_success()

--- a/test/constraints/disjunction.jl
+++ b/test/constraints/disjunction.jl
@@ -39,7 +39,7 @@ function test_disjunction_add_fail()
     @constraint(model, [i = 1:2], x == 5, Disjunct(w[i]))
     @test_throws ErrorException disjunction(model, w, Disjunct(w[3]), bad_key = 42)
 
-    @variable(model, yc[i = 1:2], Logical, logical_compliment = y[i])
+    @variable(model, yc[i = 1:2], Logical, logical_complement = y[i])
     @test_throws ErrorException disjunction(model, [yc[1]])
     @test_throws ErrorException disjunction(model, [yc[1], y[2]])
     @test_throws ErrorException disjunction(model, [y[1], yc[1]], Disjunct(y[2]))

--- a/test/constraints/indicator.jl
+++ b/test/constraints/indicator.jl
@@ -131,11 +131,11 @@ function test_extension_indicator()
     @test all([cobj.set isa MOI.Indicator for cobj in ref_cons_obj])
 end
 
-function test_indicator_compliment()
+function test_indicator_complement()
     model = GDPModel()
     @variable(model, x)
     @variable(model, y1, Logical)
-    @variable(model, y2, Logical, logical_compliment = y1)
+    @variable(model, y2, Logical, logical_complement = y1)
     y = [y1, y2]
     @constraint(model, x == 5, Disjunct(y[1]))
     @constraint(model, x <= 5, Disjunct(y[1]))
@@ -157,7 +157,7 @@ function test_indicator_compliment()
     A = [1 0; 0 1]
     @variable(model, x)
     @variable(model, y1, Logical)
-    @variable(model, y2, Logical, logical_compliment = y1)
+    @variable(model, y2, Logical, logical_complement = y1)
     y = [y1, y2]
     @constraint(model, A*[x,x] == [5,5], Disjunct(y[1]))
     @constraint(model, A*[x,x] <= [0,0], Disjunct(y[2]))
@@ -180,5 +180,5 @@ end
     test_indicator_sparse_axis()
     test_indicator_nested()
     test_extension_indicator()
-    test_indicator_compliment()
+    test_indicator_complement()
 end

--- a/test/solve.jl
+++ b/test/solve.jl
@@ -1,11 +1,11 @@
 using HiGHS
 
-function test_linear_gdp_example(m, use_compliments = false)
+function test_linear_gdp_example(m, use_complements = false)
     set_attribute(m, MOI.Silent(), true)
     @variable(m, 1 ≤ x[1:2] ≤ 9)
-    if use_compliments
+    if use_complements
         @variable(m, Y1, Logical)
-        @variable(m, Y2, Logical, logical_compliment = Y1)
+        @variable(m, Y2, Logical, logical_complement = Y1)
         Y = [Y1, Y2]
     else
         @variable(m, Y[1:2], Logical)
@@ -40,7 +40,7 @@ function test_linear_gdp_example(m, use_compliments = false)
     @test value(variable_by_name(m, "x[1]_W[2]")) ≈ 0
     @test value(variable_by_name(m, "x[2]_W[1]")) ≈ 0
     @test value(variable_by_name(m, "x[2]_W[2]")) ≈ 0
-    if !use_compliments
+    if !use_complements
         @test value(variable_by_name(m, "x[1]_Y[1]")) ≈ 0
         @test value(variable_by_name(m, "x[1]_Y[2]")) ≈ 9
         @test value(variable_by_name(m, "x[2]_Y[1]")) ≈ 0

--- a/test/variables/logical.jl
+++ b/test/variables/logical.jl
@@ -131,13 +131,13 @@ function test_lvar_delete()
     @test !is_valid(model, bvar)
 end
 
-function test_lvar_logical_compliment()
+function test_lvar_logical_complement()
     model = GDPModel()
     @variable(model, y1, Logical)
     # test addition
-    @test_throws ErrorException @variable(model, y2 == true, Logical, logical_compliment = y1)
-    @test_throws ErrorException @variable(model, y2, Logical, logical_compliment = y1, start = false)
-    @variable(model, y2, Logical, logical_compliment = y1)
+    @test_throws ErrorException @variable(model, y2 == true, Logical, logical_complement = y1)
+    @test_throws ErrorException @variable(model, y2, Logical, logical_complement = y1, start = false)
+    @variable(model, y2, Logical, logical_complement = y1)
     # test queries
     @test binary_variable(y2) == 1 - binary_variable(y1)
     @test name(y2) == "y2"
@@ -146,10 +146,10 @@ function test_lvar_logical_compliment()
     @test_throws ErrorException set_start_value(y2, false)
     @test_throws ErrorException fix(y2, false)
     @test unfix(y2) isa Nothing
-    @test has_logical_compliment(y2)
-    @test !has_logical_compliment(y1)
+    @test has_logical_complement(y2)
+    @test !has_logical_complement(y1)
     # test error for logical of logical
-    @test_throws ErrorException @variable(model, y3, Logical, logical_compliment = y2)
+    @test_throws ErrorException @variable(model, y3, Logical, logical_complement = y2)
     # test deletion
     @test delete(model, y2) isa Nothing
     @test !is_valid(model, y2)
@@ -202,7 +202,7 @@ end
         test_lvar_delete()
     end
     @testset "Logical Compliment Variables" begin
-        test_lvar_logical_compliment()
+        test_lvar_logical_complement()
     end
     @testset "Tagged Logical Variables" begin
         test_tagged_variables()


### PR DESCRIPTION
This PR closes #106. It does so by adding the `logical_complement` keyword argument when creating logical variables. For instance, we can have:
```julia
@variable(model, Y1, Logical) # binary_variable(Y1) returns a single binary
@variable(model, Y2, Logical, logical_complement = Y1) # binary_variable(Y2) = 1 - binary_variable(Y1)
```
These logical variables can then be used as normal to build disjunctions, but the underlying binary expressions avoid adding an unnecessary variable.

This works with all reformulations, but currently has the limitation that logical variables used inside nested disjunctions cannot be logical complements.